### PR TITLE
shows location of error in code when using cli (revised)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Options:
   --version               Show version number                                  [boolean]
   -d, --delimiter         Specify a custom delimiter ( i.e. <? instead of <% ) [string]
   --preprocessor-include  Allow old (pre-EJS v3) preprocessor-style includes   [boolean]
+  --no-context            Show only the error message, without errored code    [boolean]
 ```
 
 ## API

--- a/cli.js
+++ b/cli.js
@@ -18,7 +18,7 @@ const argv = require('yargs')
   }).argv;
 const glob = require('globby').sync;
 const read = require('read-input');
-// const chalk = require('chalk');
+const chalk = require('chalk');
 const ejsLint = require('./index.js');
 
 const opts = {
@@ -50,11 +50,8 @@ function errorContext(err, file) {
   const lines = file.data.split(/\r?\n/);
   const lineText = lines[err.line - 1];
   const before = lineText.substr(0, err.column - 1);
-  const during = lineText.substr(err.column - 1, 1);
+  const duringText = lineText.substr(err.column - 1, 1);
+  const during = chalk.bgRed(duringText);
   const after = lineText.substr(err.column);
-  const startRed = '\u001b[41m';
-  const endRed = '\u001b[49m';
-  // const highlightedError = chalk.bgRed(during);
-  // return before + highlightedError + after;
-  return before + startRed + during + endRed +after;
+  return before + during + after;
 }

--- a/cli.js
+++ b/cli.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 'use strict';
-require('colors');
 /* eslint-disable no-console */
 const argv = require('yargs')
   .usage(
@@ -19,6 +18,7 @@ const argv = require('yargs')
   }).argv;
 const glob = require('globby').sync;
 const read = require('read-input');
+// const chalk = require('chalk');
 const ejsLint = require('./index.js');
 
 const opts = {
@@ -52,5 +52,9 @@ function errorContext(err, file) {
   const before = lineText.substr(0, err.column - 1);
   const during = lineText.substr(err.column - 1, 1);
   const after = lineText.substr(err.column);
-  return before + during.bgRed + after;
+  const startRed = '\u001b[41m';
+  const endRed = '\u001b[49m';
+  // const highlightedError = chalk.bgRed(during);
+  // return before + highlightedError + after;
+  return before + startRed + during + endRed +after;
 }

--- a/cli.js
+++ b/cli.js
@@ -15,6 +15,10 @@ const argv = require('yargs')
   .option('preprocessor-include', {
     describe: 'Allow old (pre-EJS v3) preprocessor-style includes',
     type: 'boolean',
+  })
+  .option('no-context', {
+    describe: 'Show only the error message, without the line of errored code',
+    type: 'boolean'
   }).argv;
 const glob = require('globby').sync;
 const read = require('read-input');
@@ -24,6 +28,7 @@ const ejsLint = require('./index.js');
 const opts = {
   delimiter: argv.delimiter,
   preprocessorInclude: argv['preprocessor-include'],
+  context: argv['context'],
 };
 read(glob(argv._))
   .then((res) => {
@@ -34,9 +39,8 @@ read(glob(argv._))
         errored = true;
         let message = `${err.message} (${err.line}:${err.column})`;
         if (file.name) message += ` in ${file.name}`;
-        message += `\n${errorContext(err, file)}`;
+        if (opts.context === undefined) message += `\n${errorContext(err, file)}`;
         console.error(message);
-
       }
     });
     if (errored) process.exit(1);

--- a/cli.js
+++ b/cli.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 'use strict';
+require('colors');
 /* eslint-disable no-console */
 const argv = require('yargs')
   .usage(
@@ -33,6 +34,7 @@ read(glob(argv._))
         errored = true;
         let message = `${err.message} (${err.line}:${err.column})`;
         if (file.name) message += ` in ${file.name}`;
+        message += `\n${errorContext(err, file)}`;
         console.error(message);
       }
     });
@@ -42,3 +44,12 @@ read(glob(argv._))
     console.error(err);
     process.exit(1);
   });
+
+function errorContext(err, file) {
+  const lines = file.data.split(/\r?\n/);
+  const lineText = lines[err.line - 1];
+  const before = lineText.substr(0, err.column - 1);
+  const during = lineText.substr(err.column - 1, 1);
+  const after = lineText.substr(err.column);
+  return before + during.bgRed + after;
+}

--- a/cli.js
+++ b/cli.js
@@ -28,7 +28,7 @@ const ejsLint = require('./index.js');
 const opts = {
   delimiter: argv.delimiter,
   preprocessorInclude: argv['preprocessor-include'],
-  context: argv['context'],
+  context: argv.context,
 };
 read(glob(argv._))
   .then((res) => {

--- a/cli.js
+++ b/cli.js
@@ -20,6 +20,8 @@ const argv = require('yargs')
 const glob = require('globby').sync;
 const read = require('read-input');
 const ejsLint = require('./index.js');
+const path = require('path');
+const fs = require('fs');
 
 const opts = {
   delimiter: argv.delimiter,
@@ -36,6 +38,7 @@ read(glob(argv._))
         if (file.name) message += ` in ${file.name}`;
         message += `\n${errorContext(err, file)}`;
         console.error(message);
+
       }
     });
     if (errored) process.exit(1);

--- a/cli.js
+++ b/cli.js
@@ -53,5 +53,16 @@ function errorContext(err, file) {
   const duringText = lineText.substr(err.column - 1, 1);
   const during = chalk.bgRed(duringText);
   const after = lineText.substr(err.column);
-  return before + during + after;
+  const caret = '^';
+  const lineBreak = '\n';
+  const caretLine = addSpaces(err.column - 1) + caret;
+  return before + during + after + lineBreak +caretLine;
+}
+
+function addSpaces(n) {
+  let str = '';
+  for (let i=0; i<n; i++) {
+    str += ' ';
+  }
+  return str;
 }

--- a/cli.js
+++ b/cli.js
@@ -20,8 +20,6 @@ const argv = require('yargs')
 const glob = require('globby').sync;
 const read = require('read-input');
 const ejsLint = require('./index.js');
-const path = require('path');
-const fs = require('fs');
 
 const opts = {
   delimiter: argv.delimiter,

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "dependencies": {
     "chalk": "^4.0.0",
-    "colors": "^1.4.0",
     "ejs": "3.0.1",
     "ejs-include-regex": "^1.0.0",
     "globby": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "unit": "nyc --check-coverage mocha --ui tdd --check-leaks"
   },
   "dependencies": {
+    "colors": "^1.4.0",
     "ejs": "3.0.1",
     "ejs-include-regex": "^1.0.0",
     "globby": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "unit": "nyc --check-coverage mocha --ui tdd --check-leaks"
   },
   "dependencies": {
+    "chalk": "^4.0.0",
     "colors": "^1.4.0",
     "ejs": "3.0.1",
     "ejs-include-regex": "^1.0.0",

--- a/test/cli.js
+++ b/test/cli.js
@@ -4,7 +4,6 @@ const assert = require('assert');
 const execFile = require('child_process').execFile;
 const path = require('path');
 const ejslint = path.resolve('cli.js');
-const chalk = require('chalk');
 
 suite('cli', () => {
   test('valid input', (done) => {
@@ -16,8 +15,7 @@ suite('cli', () => {
   });
   test('invalid input', (done) => {
     execFile(ejslint, ['test/fixtures/invalid.ejs'], (err, stdout, stderr) => {
-      const errorText = chalk.bgRed(']');
-      const expectedContext = `\n<% ${errorText} %>`;
+      const expectedContext = `\n<% ] %>`;
       assert.equal(err.code, 1, 'expected exit code of 1');
       assert.equal(
         stderr.trim(),

--- a/test/cli.js
+++ b/test/cli.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const execFile = require('child_process').execFile;
 const path = require('path');
 const ejslint = path.resolve('cli.js');
-require('colors');
+const colors = require('colors');
 
 suite('cli', () => {
   test('valid input', (done) => {

--- a/test/cli.js
+++ b/test/cli.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const execFile = require('child_process').execFile;
 const path = require('path');
 const ejslint = path.resolve('cli.js');
-const colors = require('colors');
+require('colors');
 
 suite('cli', () => {
   test('valid input', (done) => {

--- a/test/cli.js
+++ b/test/cli.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const execFile = require('child_process').execFile;
 const path = require('path');
 const ejslint = path.resolve('cli.js');
-require('colors');
+const chalk = require('chalk');
 
 suite('cli', () => {
   test('valid input', (done) => {
@@ -16,7 +16,8 @@ suite('cli', () => {
   });
   test('invalid input', (done) => {
     execFile(ejslint, ['test/fixtures/invalid.ejs'], (err, stdout, stderr) => {
-      const expectedContext = `\n<% ${']'.bgRed} %>`;
+      const errorText = chalk.bgRed(']');
+      const expectedContext = `\n<% ${errorText} %>`;
       assert.equal(err.code, 1, 'expected exit code of 1');
       assert.equal(
         stderr.trim(),

--- a/test/cli.js
+++ b/test/cli.js
@@ -15,7 +15,7 @@ suite('cli', () => {
   });
   test('invalid input', (done) => {
     execFile(ejslint, ['test/fixtures/invalid.ejs'], (err, stdout, stderr) => {
-      const expectedContext = `\n<% ] %>`;
+      const expectedContext = `\n<% ] %>\n   ^`;
       assert.equal(err.code, 1, 'expected exit code of 1');
       assert.equal(
         stderr.trim(),

--- a/test/cli.js
+++ b/test/cli.js
@@ -24,6 +24,16 @@ suite('cli', () => {
       done();
     });
   });
+  test('invalid input --no-context option', (done) => {
+    execFile(ejslint, ['test/fixtures/invalid.ejs', '--no-context'], (err, stdout, stderr) => {
+      assert.equal(err.code, 1, 'expected exit code of 1');
+      assert.equal(
+        stderr.trim(),
+        `Unexpected token (3:4) in test/fixtures/invalid.ejs`,
+      );
+      done();
+    });
+  });
   test('--preprocessor-include option', (done) => {
     execFile(
       ejslint,

--- a/test/cli.js
+++ b/test/cli.js
@@ -4,6 +4,7 @@ const assert = require('assert');
 const execFile = require('child_process').execFile;
 const path = require('path');
 const ejslint = path.resolve('cli.js');
+require('colors');
 
 suite('cli', () => {
   test('valid input', (done) => {
@@ -15,10 +16,11 @@ suite('cli', () => {
   });
   test('invalid input', (done) => {
     execFile(ejslint, ['test/fixtures/invalid.ejs'], (err, stdout, stderr) => {
+      const expectedContext = `\n<% ${']'.bgRed} %>`;
       assert.equal(err.code, 1, 'expected exit code of 1');
       assert.equal(
         stderr.trim(),
-        'Unexpected token (3:4) in test/fixtures/invalid.ejs',
+        `Unexpected token (3:4) in test/fixtures/invalid.ejs${expectedContext}`,
       );
       done();
     });

--- a/test/cli.js
+++ b/test/cli.js
@@ -25,14 +25,18 @@ suite('cli', () => {
     });
   });
   test('invalid input --no-context option', (done) => {
-    execFile(ejslint, ['test/fixtures/invalid.ejs', '--no-context'], (err, stdout, stderr) => {
-      assert.equal(err.code, 1, 'expected exit code of 1');
-      assert.equal(
-        stderr.trim(),
-        `Unexpected token (3:4) in test/fixtures/invalid.ejs`,
-      );
-      done();
-    });
+    execFile(
+      ejslint,
+      ['test/fixtures/invalid.ejs', '--no-context'],
+      (err, stdout, stderr) => {
+        assert.equal(err.code, 1, 'expected exit code of 1');
+        assert.equal(
+          stderr.trim(),
+          `Unexpected token (3:4) in test/fixtures/invalid.ejs`,
+        );
+        done();
+      },
+    );
   });
   test('--preprocessor-include option', (done) => {
     execFile(


### PR DESCRIPTION
Closes #70

- adds errorContext() function in cli
- displays the text of the line containing the error
- highlights the offending character in red
- adds a line below the code using a caret `^` to show where the error occurred (more accessible for some users than colored highlighting)
- updates the "invalid" test to account for new expected output
- supports both file-based and inline cli inputs
- adds a `--no-context` option to suppress the new feature
- updates the README file with info about the `--no-context` option